### PR TITLE
mobile/Delete Community

### DIFF
--- a/mobile/FaceSpace/.idea/misc.xml
+++ b/mobile/FaceSpace/.idea/misc.xml
@@ -13,7 +13,7 @@
         <entry key="app/src/main/res/layout-v23/community_item.xml" value="0.29270833333333335" />
         <entry key="app/src/main/res/layout-w1240dp/activity_login.xml" value="0.2285809906291834" />
         <entry key="app/src/main/res/layout-w936dp/activity_login.xml" value="0.266796875" />
-        <entry key="app/src/main/res/layout/activity_communities_page.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/activity_communities_page.xml" value="0.25" />
         <entry key="app/src/main/res/layout/activity_community_page.xml" value="0.3375" />
         <entry key="app/src/main/res/layout/activity_create_data_type.xml" value="0.25" />
         <entry key="app/src/main/res/layout/activity_create_post.xml" value="0.25" />
@@ -26,15 +26,14 @@
         <entry key="app/src/main/res/layout/activity_login_page.xml" value="0.35572916666666665" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.33" />
         <entry key="app/src/main/res/layout/activity_maps.xml" value="0.19791666666666666" />
-        <entry key="app/src/main/res/layout/activity_my_communities.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/activity_my_communities.xml" value="0.25" />
         <entry key="app/src/main/res/layout/activity_popup_unsubscribed_comm.xml" value="0.1" />
         <entry key="app/src/main/res/layout/activity_post.xml" value="0.22268907563025211" />
-        <entry key="app/src/main/res/layout/activity_profile_page.xml" value="0.33" />
-        <entry key="app/src/main/res/layout/activity_search_posts.xml" value="0.35572916666666665" />
+        <entry key="app/src/main/res/layout/activity_profile_page.xml" value="0.19157608695652173" />
+        <entry key="app/src/main/res/layout/activity_search_posts.xml" value="0.140625" />
         <entry key="app/src/main/res/layout/activity_sign_up_page.xml" value="0.27644710578842313" />
         <entry key="app/src/main/res/layout/community_item.xml" value="0.375" />
         <entry key="app/src/main/res/layout/data_type_field_item.xml" value="0.45" />
-        <entry key="app/src/main/res/layout/filter_item.xml" value="0.33" />
         <entry key="app/src/main/res/layout/fragment_create_community.xml" value="0.33" />
         <entry key="app/src/main/res/layout/fragment_edit_profile.xml" value="0.140625" />
         <entry key="app/src/main/res/layout/post_item.xml" value="0.335" />

--- a/mobile/FaceSpace/app/src/main/java/com/example/facespace/CommunityAdapter.kt
+++ b/mobile/FaceSpace/app/src/main/java/com/example/facespace/CommunityAdapter.kt
@@ -85,6 +85,12 @@ class CommunityAdapter (
         }
     }
 
+    fun deleteComm(comm: Community) {
+        val index = communities.indexOf(comm)
+        communities.remove(comm)
+        notifyItemRemoved(index)
+    }
+
     override fun getItemCount(): Int {
         return communities.size
     }

--- a/mobile/FaceSpace/app/src/main/java/com/example/facespace/InsidePost.kt
+++ b/mobile/FaceSpace/app/src/main/java/com/example/facespace/InsidePost.kt
@@ -19,9 +19,6 @@ import org.json.JSONException
 import org.json.JSONObject
 import android.R.attr.data
 
-
-
-
 class InsidePost : AppCompatActivity() {
     private lateinit var postAdapter: PostAdapter
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,8 +34,6 @@ class InsidePost : AppCompatActivity() {
         val post_creator = JSONObject(post_data["postedBy"].toString())["username"].toString()
         val comm_creator = JSONObject(comm_data["createdBy"].toString())["username"].toString()
         val postId = post_data["id"].toString()
-        val commId = comm_data["id"].toString()
-        Toast.makeText(this,"BURADAYIM BU DA COMMID: $commId", Toast.LENGTH_SHORT).show()
 
         val btnAdd = findViewById<FloatingActionButton>(R.id.btnAddP)
         val btnRefresh = findViewById<FloatingActionButton>(R.id.btnRefreshP)

--- a/mobile/FaceSpace/app/src/main/res/layout/activity_community_page.xml
+++ b/mobile/FaceSpace/app/src/main/res/layout/activity_community_page.xml
@@ -224,14 +224,27 @@
 
         <Button
             android:id="@+id/btnSubscribe"
-            android:layout_width="117dp"
+            android:layout_width="125dp"
             android:layout_height="41dp"
             android:layout_marginTop="10dp"
-            android:backgroundTint="#CE0BD5"
+            android:backgroundTint="@color/purple_500"
             android:enabled="true"
             android:text="@string/unsubscribe"
             android:textColor="#FFFFFF"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/communityDate" />
+
+        <Button
+            android:id="@+id/btnDeleteComm"
+            android:layout_width="117dp"
+            android:layout_height="60dp"
+            android:layout_marginStart="20dp"
+            android:backgroundTint="@color/red"
+            android:enabled="true"
+            android:text="Delete Community"
+            android:textColor="#FFFFFF"
+            android:textSize="14sp"
+            app:layout_constraintStart_toEndOf="@+id/btnSubscribe"
             app:layout_constraintTop_toBottomOf="@+id/communityDate" />
 
         <TextView


### PR DESCRIPTION
Implemented 'Delete Community' feature. Now the user can delete communities from the mobile application.
* The user has to be the moderator (creator) of the community to have the option of deleting the community. Once deleted, the user is redirected to home page.